### PR TITLE
HDDS-5081. Fix key put implementation

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -197,7 +197,7 @@ func main() {
 					Action: func(c *cli.Context) error {
 						ozoneClient := api.CreateOzoneClient(c.GlobalString("om"))
 						address := OzoneObjectAddressFromString(c.Args().Get(0))
-						f, err := os.Open("/tmp/asd")
+						f, err := os.Open(c.Args().Get(1)
 						if err != nil {
 							return err
 						}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace hard-coded `/tmp/asd` local file with command-line argument for `key put` operation.

https://issues.apache.org/jira/browse/HDDS-5081

## How was this patch tested?

```
./ozone-go --om localhost key put vol1/bucket1/passwd /etc/passwd
```

NOTE: this PR is intentionally created with a compile error.